### PR TITLE
changed references from henrikrexed to Dynatrace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: go install go.k6.io/xk6/cmd/xk6@latest
 
       - name: Build the binary
-        run: xk6 build --with github.com/henrikrexed/xk6-dynatrace-output=.
+        run: xk6 build --with github.com/Dynatrace/xk6-dynatrace-output=.
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR $GOPATH/src/go.k6.io/k6
 ADD . .
 RUN apk --no-cache add git
 RUN CGO_ENABLED=0 go install go.k6.io/xk6/cmd/xk6@latest
-RUN CGO_ENABLED=0 xk6 build --output /k6  --with github.com/henrikrexed/xk6-output-dynatrace=.
+RUN CGO_ENABLED=0 xk6 build --output /k6  --with github.com/Dynatrace/xk6-output-dynatrace=.
 
 FROM grafana/k6:latest
 COPY --from=builder /k6 /usr/bin/k6

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 # xk6-output-dynatrace
 k6 extension for publishing test-run metrics to Dynatrace 
 
+Invented by: github.com/henrikrexed
+
 
 ### Usage
 
 To build k6 binary with the Prometheus remote write output extension use:
 ```
-xk6 build --with github.com/henrikrexed/xk6-output-dynatrace@latest 
+xk6 build --with github.com/Dynatrace/xk6-output-dynatrace@latest 
 ```
 
 Then run new k6 binary with:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/henrikrexed/xk6-output-dynatrace
+module github.com/Dynatrace/xk6-output-dynatrace
 
 go 1.16
 

--- a/register.go
+++ b/register.go
@@ -1,7 +1,7 @@
 package dynatracewriter
 
 import (
-	"github.com/henrikrexed/xk6-output-dynatrace/pkg/dynatracewriter"
+	"github.com/Dynatrace/xk6-output-dynatrace/pkg/dynatracewriter"
 	"go.k6.io/k6/output"
 )
 


### PR DESCRIPTION
Hi guys - I kept getting an error on building k6:

module declares its path as: [github.com/henrikrexed/xk6-output-dynatrace](http://github.com/henrikrexed/xk6-output-dynatrace)
                but was required as: [github.com/Dynatrace/xk6-output-dynatrace](http://github.com/Dynatrace/xk6-output-dynatrace)
                
               
So this PR will fix the path references from henrikrexed to be Dynatrace.

