### PR TITLE
update compatibility to v0.43.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
         github.com/gorilla/schema v1.2.0
         github.com/sirupsen/logrus v1.8.1
-        go.k6.io/k6 v0.40.0
+        go.k6.io/k6 v0.43.1
 
 )

--- a/pkg/dynatracewriter/dynatraceMetric.go
+++ b/pkg/dynatracewriter/dynatraceMetric.go
@@ -27,7 +27,7 @@ type dynatraceMetric struct{
 func samleToDynametric(sample metrics.Sample ) dynatraceMetric {
      return dynatraceMetric{
         metricKeyName : sample.Metric.Name,
-        metricDimensions : sample.GetTags().CloneTags(),
+        metricDimensions : sample.GetTags().Map(),
         metricValue : sample.Value,
         metricTimeStamp : sample.GetTime().UnixMilli(),
      }


### PR DESCRIPTION
Update to the k6 latest version, breaking changes in [v0.41.0](https://github.com/grafana/k6/releases/tag/v0.41.0), [`metrics.Sample.CloneTags()`](https://github.com/grafana/k6/blob/v0.40.0/metrics/sample.go#LL281C23-L281C34) was removed. 