### PR TITLE
feat: update k6 to v0.45.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/Dynatrace/xk6-output-dynatrace
 
-go 1.16
+go 1.19
 
 require (
         github.com/gorilla/schema v1.2.0
         github.com/sirupsen/logrus v1.8.1
-        go.k6.io/k6 v0.43.1
+        go.k6.io/k6 v0.45.1
 
 )


### PR DESCRIPTION
A transitive dependency was removed. v0.45.0 was patched to address the issue. See https://github.com/grafana/k6/issues/3252.